### PR TITLE
SICM - Chapter 1.4

### DIFF
--- a/src/net/littleredcomputer/math/env.clj
+++ b/src/net/littleredcomputer/math/env.clj
@@ -17,7 +17,7 @@
 ;
 
 (ns net.littleredcomputer.math.env
-  (:refer-clojure :exclude [+ - * / zero? ])  ;; partial]) ;; I'm partial to it
+  (:refer-clojure :exclude [+ - * / zero? partial])
   (:require [net.littleredcomputer.math
              [generic :as g]
              [structure :as s]
@@ -85,4 +85,4 @@
 (def ∂ d/pd)
 (def pd d/pd)
 
-(def Pi (* 2 (asin 1)))
+(def Pi (* 2 (asin 1)))  ;; used in SICM code - albeit as :pi

--- a/src/net/littleredcomputer/math/env.clj
+++ b/src/net/littleredcomputer/math/env.clj
@@ -17,7 +17,7 @@
 ;
 
 (ns net.littleredcomputer.math.env
-  (:refer-clojure :exclude [+ - * / zero? partial])
+  (:refer-clojure :exclude [+ - * / zero? ])  ;; partial]) ;; I'm partial to it
   (:require [net.littleredcomputer.math
              [generic :as g]
              [structure :as s]
@@ -84,3 +84,5 @@
 (def D d/D)
 (def ∂ d/pd)
 (def pd d/pd)
+
+(def Pi (* 2 (asin 1)))

--- a/src/net/littleredcomputer/math/mechanics/lagrange.clj
+++ b/src/net/littleredcomputer/math/mechanics/lagrange.clj
@@ -22,6 +22,7 @@
              [generic :refer :all]
              [structure :refer :all]
              [function :refer :all]]
+            [net.littleredcomputer.math.numerical.minimize :refer :all]
             [net.littleredcomputer.math.numerical.integrate :refer :all]
             [net.littleredcomputer.math.calculus.derivative :refer :all]))
 

--- a/src/net/littleredcomputer/math/mechanics/lagrange.clj
+++ b/src/net/littleredcomputer/math/mechanics/lagrange.clj
@@ -223,3 +223,32 @@
   (fn [[_ [q0 q1] qdot]]  ;; local
     (- (* 1/2 m (square qdot))
        (V q0 q1))))
+
+;; more functions from SICM, ch 1.4  
+
+(defn make-path 
+  "SICM 1st ed.  Ch 1.4 footnote #44 p.22"
+  [t0 q0 t1 q1 qs]
+  (let [ts (linear-interpolants t0 t1 (count qs))]
+    (Lagrange-interpolation-function
+      (concat (list q0) qs (list q1))
+      (concat (list t0) ts (list t1)))))
+  
+  
+(defn parametric-path-action 
+  "SICM 1st ed.  Ch 1.4 p.23"
+  [Lagrangian t0 q0 t1 q1]
+  (fn [qs]
+    (let [path (make-path t0 q0 t1 q1 qs)]
+      (Lagrangian-action Lagrangian path t0 t1))))
+      
+
+(defn find-path 
+  "SICM 1st ed.  Ch 1.4 p.23"
+  [Lagrangian t0 q0 t1 q1 n]
+  (let [initial-qs (linear-interpolants q0 q1 n)
+        minimizing-qs (multidimensional-minimize 
+                         (parametric-path-action Lagrangian t0 q0 t1 q1) 
+                         initial-qs)]
+    (make-path t0 q0 t1 q1 minimizing-qs)))
+     


### PR DESCRIPTION
The functions from Ch. 1.4 , Computing Actions, as per #10
I've also added a Pi to env, might as well, move it if you think there's a better place for it.
PS.
Oops, lagrange also requires minimize. I think it's all there now... runs fine here.
PPS.
Ah, I see there is a clash in Travis, since you've already got "make-path" and some others in 
*.math.sicm-ch1-test

I wonder if they should be moved into *.math.mechanics.lagrange, or perhaps even a separate SICMbook directory from where they can be made globally available, they are available out of the box under scmutils.
